### PR TITLE
"Provider compatibility across versions" and "Provider compatibility for PRs" tests modification.

### DIFF
--- a/.github/workflows/prov-compat-label.yml
+++ b/.github/workflows/prov-compat-label.yml
@@ -114,10 +114,6 @@ jobs:
             dir: branch-3.0,
             tgz: branch-3.0.tar.gz,
           }, {
-            name: openssl-3.2,
-            dir: branch-3.2,
-            tgz: branch-3.2.tar.gz,
-          }, {
             name: openssl-3.3,
             dir: branch-3.3,
             tgz: branch-3.3.tar.gz,
@@ -202,12 +198,14 @@ jobs:
         # Note that releases are not used as a test environment for
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
-        tree_a: [ branch-3.5, branch-3.4, branch-3.3, branch-3.2, branch-3.0,
+        tree_a: [ branch-3.6, branch-3.5, branch-3.4, branch-3.3, branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ PR ]
         include:
           - tree_a: PR
             tree_b: branch-master
+          - tree_a: PR
+            tree_b: branch-3.6
           - tree_a: PR
             tree_b: branch-3.5
           - tree_a: PR
@@ -215,45 +213,48 @@ jobs:
           - tree_a: PR
             tree_b: branch-3.3
           - tree_a: PR
-            tree_b: branch-3.2
-          - tree_a: PR
             tree_b: branch-3.0
     steps:
       - name: early exit checks
         id: early_exit
+        env:
+          B_BRANCH: ${{ matrix.tree_b }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          if [ "${{ matrix.tree_a }}" = "${{ matrix.tree_b }}" ];           \
-          then                                                              \
-            echo "Skipping because both are the same version";              \
-            exit 1;                                                         \
+          b_ver=${B_BRANCH#branch-}
+          b_label="branch: $b_ver"
+          if [[ "$PR_LABELS" == *"$b_label"* ]]; then
+            echo "Skipping branches modified by the PR"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-        continue-on-error: true
 
       - uses: actions/download-artifact@v6.0.0
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         with:
           name: ${{ matrix.tree_a }}.tar.gz
       - name: unpack first build
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: tar xzf "${{ matrix.tree_a }}.tar.gz"
 
       - uses: actions/download-artifact@v6.0.0
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         with:
           name: ${{ matrix.tree_b }}.tar.gz
       - name: unpack second build
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: tar xzf "${{ matrix.tree_b }}.tar.gz"
 
       - name: set up cross validation of FIPS from A with tree from B
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           cp providers/fips.so ../${{ matrix.tree_b }}/providers/
           cp providers/fipsmodule.cnf ../${{ matrix.tree_b }}/providers/
         working-directory: ${{ matrix.tree_a }}
 
       - name: show module versions from cross validation
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           ./util/wrap.pl -fips apps/openssl list -provider-path providers   \
                                                  -provider base             \
@@ -264,14 +265,14 @@ jobs:
         working-directory: ${{ matrix.tree_b }}
 
       - name: get cpu info
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           cat /proc/cpuinfo
           ./util/opensslwrap.sh version -c
         working-directory: ${{ matrix.tree_b }}
 
       - name: run cross validation tests of FIPS from A with tree from B
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ${{ matrix.tree_b }}

--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -120,11 +120,6 @@ jobs:
             tgz: branch-3.0.tar.gz,
             extra_config: "",
           }, {
-            name: openssl-3.2,
-            dir: branch-3.2,
-            tgz: branch-3.2.tar.gz,
-            extra_config: "",
-          }, {
             name: openssl-3.3,
             dir: branch-3.3,
             tgz: branch-3.3.tar.gz,
@@ -219,46 +214,46 @@ jobs:
         # later providers.  Problems in these situations ought to be
         # caught by cross branch testing before the release.
         tree_a: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.3,
-                  branch-3.2, branch-3.0,
+                  branch-3.0,
                   openssl-3.0.0, openssl-3.0.8, openssl-3.0.9, openssl-3.1.2 ]
         tree_b: [ branch-master, branch-3.6, branch-3.5, branch-3.4, branch-3.3,
-                  branch-3.2, branch-3.0  ]
+                  branch-3.0  ]
     steps:
       - name: early exit checks
         id: early_exit
         run: |
-          if [ "${{ matrix.tree_a }}" = "${{ matrix.tree_b }}" ];           \
-          then                                                              \
-            echo "Skipping because both are the same version";              \
-            exit 1;                                                         \
+          if [ "${{ matrix.tree_a }}" = "${{ matrix.tree_b }}" ]; then
+            echo "Skipping because both are the same version"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-        continue-on-error: true
 
       - uses: actions/download-artifact@v6.0.0
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         with:
           name: ${{ matrix.tree_a }}.tar.gz
       - name: unpack first build
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: tar xzf "${{ matrix.tree_a }}.tar.gz"
 
       - uses: actions/download-artifact@v6.0.0
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         with:
           name: ${{ matrix.tree_b }}.tar.gz
       - name: unpack second build
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: tar xzf "${{ matrix.tree_b }}.tar.gz"
 
       - name: set up cross validation of FIPS from A with tree from B
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           cp providers/fips.so ../${{ matrix.tree_b }}/providers/
           cp providers/fipsmodule.cnf ../${{ matrix.tree_b }}/providers/
         working-directory: ${{ matrix.tree_a }}
 
       - name: show module versions from cross validation
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           ./util/wrap.pl -fips apps/openssl list -provider-path providers   \
                                                  -provider base             \
@@ -269,14 +264,14 @@ jobs:
         working-directory: ${{ matrix.tree_b }}
 
       - name: get cpu info
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           cat /proc/cpuinfo
           ./util/opensslwrap.sh version -c
         working-directory: ${{ matrix.tree_b }}
 
       - name: run cross validation tests of FIPS from A with tree from B
-        if: steps.early_exit.outcome == 'success'
+        if: steps.early_exit.outputs.skip != 'true'
         run: |
           make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ${{ matrix.tree_b }}


### PR DESCRIPTION
Branch 3.2 was removed from and branch 3.6 was added to the "Provider compatibility across versions" and "Provider compatibility for PRs" tests.

The "early exit checks" code was modified to avoid red labels.

Skip testing the provider from the PR against modified branches, reasons are following (formulated by @t8m):

We do not aim for compatibility of a random FIPS provider with random snapshot of a tree. What matters is compatibility between released versions of FIPS provider and the latest code on the particular branch.

For that reason I think it would be wrong to skip the testcase which runs the FIPS provider from the branch-x.y with the tree from the PR which targets the branch-x.y. OTOH skipping the testcase which runs the FIPS provider from the PR targeting the branch-x.y against the unmodified tree from branch-x.y makes sense.




<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
